### PR TITLE
Update UMD to have an export

### DIFF
--- a/lib/tasks/Make.js
+++ b/lib/tasks/Make.js
@@ -22,9 +22,7 @@ const
         root.returnExports = factory(root.riot);
     }
 }(this, function (riot) {
-    // Just return a value to define the module export.
-    // This example returns an object, but the module
-    // can return a function as the exported value.
+    // Return the tag to define the module export.
     return `,
   END_FRAG = '}));'
 

--- a/lib/tasks/Make.js
+++ b/lib/tasks/Make.js
@@ -8,17 +8,25 @@ const
   path = require('path'),
   sh = require('shelljs'),
   START_FRAG = `
-(function(tagger) {
-  if (typeof define === 'function' && define.amd) {
-    define(function(require, exports, module) { tagger(require('riot'), require, exports, module)})
-  } else if (typeof module !== 'undefined' && typeof module.exports !== 'undefined') {
-    tagger(require('riot'), require, exports, module)
-  } else {
-    tagger(window.riot)
-  }
-})(function(riot, require, exports, module) {
-`,
-  END_FRAG = '});'
+(function (root, factory) {
+    if (typeof define === 'function' && define.amd) {
+        // AMD. Register as an anonymous module.
+        define(['riot'], factory);
+    } else if (typeof module === 'object' && module.exports) {
+        // Node. Does not work with strict CommonJS, but
+        // only CommonJS-like environments that support module.exports,
+        // like Node.
+        module.exports = factory(require('riot'));
+    } else {
+        // Browser globals (root is window)
+        root.returnExports = factory(root.riot);
+    }
+}(this, function (riot) {
+    // Just return a value to define the module export.
+    // This example returns an object, but the module
+    // can return a function as the exported value.
+    return `,
+  END_FRAG = '}));'
 
 
 /**


### PR DESCRIPTION
https://github.com/umdjs/umd/blob/6e693154138b111e17b264e4e27f76e6116f1aba/returnExports.js#L17-L37

Update the UMD to an export variant to allow for node `require`-ing of pre-compiled tags that used the `--modular` flag.