### PR TITLE
Fix modular compilation ouput when compiling tags to a file. (Fixes #7)

### DIFF
--- a/lib/tasks/Make.js
+++ b/lib/tasks/Make.js
@@ -68,9 +68,9 @@ class Make extends Task {
    */
   toFile(from, to, opt) {
     this.encapsulate(
-      from.map((path) => this.parse(path, opt)).join('\n').to(to[0]),
+      from.map((path) => this.parse(path, opt)).join('\n'),
       opt
-    )
+    ).to(to[0])
   }
   /**
    * Write all the tags compiled in several files on the file system


### PR DESCRIPTION
The ```--modular``` option doesn't work when compiling tags to a file