### PR TITLE
Missing config parameter

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -89,7 +89,9 @@ function cli(ar) {
         expr: args.expr,
         modular: args.modular,
         silent: args.silent,
-        whitespace: args.whitespace
+        whitespace: args.whitespace,
+        parser: args.parser,
+        parserOptions: args.parserOptions,
       },
       ext: args.ext,
       css: args.css,
@@ -98,7 +100,7 @@ function cli(ar) {
       colors: args.colors,
       parsers: args.parsers, // to extend the default compiler parsers
       from: args.from || args._.shift(),
-      to: args.to || args._.shift()
+      to: args.to || args._.shift(),
     }
 
     // Call matching method


### PR DESCRIPTION
Missing 'parsers' & 'parserOptions'

See: http://riotjs.com/guide/compiler/