### PR TITLE
adds es6 modular option

### DIFF
--- a/lib/const.js
+++ b/lib/const.js
@@ -18,6 +18,8 @@ module.exports = Object.freeze({
 })(function(riot, require, exports, module) {
 `,
   MODULAR_END_FRAG: '});',
+  ES_MODULAR_START_FRAG: `import riot from 'riot';
+  `,
   TAG_CREATED_CORRECTLY: function(path) {
     return `${path} created correctly!`
   },

--- a/lib/const.js
+++ b/lib/const.js
@@ -18,7 +18,7 @@ module.exports = Object.freeze({
 })(function(riot, require, exports, module) {
 `,
   MODULAR_END_FRAG: '});',
-  ES_MODULAR_START_FRAG: `import riot from 'riot';
+  ES_MODULE_RIOT_IMPORT: `import riot from 'riot';
   `,
   TAG_CREATED_CORRECTLY: function(path) {
     return `${path} created correctly!`

--- a/lib/options.js
+++ b/lib/options.js
@@ -70,6 +70,12 @@ Version ${ helpers.getVersion() }
       description: 'AMD and CommonJS'
     },
     {
+      option: 'es6Modular',
+      alias: 'M',
+      type: 'Boolean',
+      description: 'es6 module'
+    },
+    {
       option: 'silent',
       alias: 's',
       type: 'Boolean',

--- a/lib/options.js
+++ b/lib/options.js
@@ -70,8 +70,7 @@ Version ${ helpers.getVersion() }
       description: 'AMD and CommonJS'
     },
     {
-      option: 'es6Modular',
-      alias: 'M',
+      option: 'esm',
       type: 'Boolean',
       description: 'es6 module'
     },

--- a/lib/tasks/Make.js
+++ b/lib/tasks/Make.js
@@ -10,7 +10,7 @@ const
   constants = require('./../const'),
   START_FRAG = constants.MODULAR_START_FRAG,
   END_FRAG = constants.MODULAR_END_FRAG,
-  ES_MODULAR_START_FRAG = constants.ES_MODULAR_START_FRAG
+  ES_MODULE_RIOT_IMPORT = constants.ES_MODULE_RIOT_IMPORT
 
 /**
  * Compile the tags using the riot-compiler
@@ -152,7 +152,7 @@ function parse (tag, opt, url) {
  */
 function encapsulate (from, opt) {
   if (opt.compiler.modular) return `${START_FRAG}${from}${END_FRAG}`
-  if (opt.compiler.es6Modular) return `${ES_MODULAR_START_FRAG}${from}`
+  if (opt.compiler.esm) return `${ES_MODULE_RIOT_IMPORT}${from}`
   return from
 }
 

--- a/lib/tasks/Make.js
+++ b/lib/tasks/Make.js
@@ -9,7 +9,8 @@ const
   co = require('co'),
   constants = require('./../const'),
   START_FRAG = constants.MODULAR_START_FRAG,
-  END_FRAG = constants.MODULAR_END_FRAG
+  END_FRAG = constants.MODULAR_END_FRAG,
+  ES_MODULAR_START_FRAG = constants.ES_MODULAR_START_FRAG
 
 /**
  * Compile the tags using the riot-compiler
@@ -150,7 +151,9 @@ function parse (tag, opt, url) {
  * @returns { String } wrapped output
  */
 function encapsulate (from, opt) {
-  return !opt.compiler.modular ? from : `${START_FRAG}${from}${END_FRAG}`
+  if (opt.compiler.modular) return `${START_FRAG}${from}${END_FRAG}`
+  if (opt.compiler.es6Modular) return `${ES_MODULAR_START_FRAG}${from}`
+  return from
 }
 
 module.exports = Make

--- a/test/expected/logs/empty.log
+++ b/test/expected/logs/empty.log
@@ -8,7 +8,7 @@ Options:
   -w, --watch          Watch for changes
   -c, --compact        Minify </p> <p> to </p><p>
   -m, --modular        AMD and CommonJS
-  -M, --es6Modular     es6 module
+  --esm                es6 module
   -s, --silent         Silence build output
   --whitespace         Preserve newlines and whitepace
   --sourcemap          Add inline sourcemaps to the generated files

--- a/test/expected/logs/empty.log
+++ b/test/expected/logs/empty.log
@@ -8,6 +8,7 @@ Options:
   -w, --watch          Watch for changes
   -c, --compact        Minify </p> <p> to </p><p>
   -m, --modular        AMD and CommonJS
+  -M, --es6Modular     es6 module
   -s, --silent         Silence build output
   --whitespace         Preserve newlines and whitepace
   --sourcemap          Add inline sourcemaps to the generated files

--- a/test/expected/logs/help.log
+++ b/test/expected/logs/help.log
@@ -8,7 +8,7 @@ Options:
   -w, --watch          Watch for changes
   -c, --compact        Minify </p> <p> to </p><p>
   -m, --modular        AMD and CommonJS
-  -M, --es6Modular     es6 module
+  --esm                es6 module
   -s, --silent         Silence build output
   --whitespace         Preserve newlines and whitepace
   --sourcemap          Add inline sourcemaps to the generated files

--- a/test/expected/logs/help.log
+++ b/test/expected/logs/help.log
@@ -8,6 +8,7 @@ Options:
   -w, --watch          Watch for changes
   -c, --compact        Minify </p> <p> to </p><p>
   -m, --modular        AMD and CommonJS
+  -M, --es6Modular     es6 module
   -s, --silent         Silence build output
   --whitespace         Preserve newlines and whitepace
   --sourcemap          Add inline sourcemaps to the generated files

--- a/test/specs/api.spec.js
+++ b/test/specs/api.spec.js
@@ -81,27 +81,27 @@ describe('API methods', function() {
     expect(cat(`${GENERATED_FOLDER}/make-components.js`)).to.match(/require/)
   })
 
-  it('make using the es6Modular flag on a single tag must return compliant es6 module code', function* () {
+  it('make using the esm flag on a single tag must return compliant esm module code', function* () {
     yield cli.make({
       from: `${TAGS_FOLDER}/component.tag`,
-      to: `${GENERATED_FOLDER}/make-es6-component.js`,
-      compiler: { es6Modular: true }
+      to: `${GENERATED_FOLDER}/make-esm-component.js`,
+      compiler: { esm: true }
     })
 
-    expect(test('-e', `${GENERATED_FOLDER}/make-es6-component.js`)).to.be(true)
-    expect(cat(`${GENERATED_FOLDER}/make-es6-component.js`)).to.match(/import/)
+    expect(test('-e', `${GENERATED_FOLDER}/make-esm-component.js`)).to.be(true)
+    expect(cat(`${GENERATED_FOLDER}/make-esm-component.js`)).to.match(/import/)
 
   })
 
-  it('make using the es6Modular flag on multiple tags must return compliant es6 module code', function* () {
+  it('make using the esm flag on multiple tags must return compliant esm module code', function* () {
     yield cli.make({
       from: `${TAGS_FOLDER}`,
-      to: `${GENERATED_FOLDER}/make-es6-components.js`,
-      compiler: { es6Modular: true }
+      to: `${GENERATED_FOLDER}/make-esm-components.js`,
+      compiler: { esm: true }
     })
 
-    expect(test('-e', `${GENERATED_FOLDER}/make-es6-components.js`)).to.be(true)
-    expect(cat(`${GENERATED_FOLDER}/make-es6-components.js`)).to.match(/import/)
+    expect(test('-e', `${GENERATED_FOLDER}/make-esm-components.js`)).to.be(true)
+    expect(cat(`${GENERATED_FOLDER}/make-esm-components.js`)).to.match(/import/)
   })
 
   it('make using a missing preprocessor should throw an error', function* () {

--- a/test/specs/api.spec.js
+++ b/test/specs/api.spec.js
@@ -81,6 +81,29 @@ describe('API methods', function() {
     expect(cat(`${GENERATED_FOLDER}/make-components.js`)).to.match(/require/)
   })
 
+  it('make using the es6Modular flag on a single tag must return compliant es6 module code', function* () {
+    yield cli.make({
+      from: `${TAGS_FOLDER}/component.tag`,
+      to: `${GENERATED_FOLDER}/make-es6-component.js`,
+      compiler: { es6Modular: true }
+    })
+
+    expect(test('-e', `${GENERATED_FOLDER}/make-es6-component.js`)).to.be(true)
+    expect(cat(`${GENERATED_FOLDER}/make-es6-component.js`)).to.match(/import/)
+
+  })
+
+  it('make using the es6Modular flag on multiple tags must return compliant es6 module code', function* () {
+    yield cli.make({
+      from: `${TAGS_FOLDER}`,
+      to: `${GENERATED_FOLDER}/make-es6-components.js`,
+      compiler: { es6Modular: true }
+    })
+
+    expect(test('-e', `${GENERATED_FOLDER}/make-es6-components.js`)).to.be(true)
+    expect(cat(`${GENERATED_FOLDER}/make-es6-components.js`)).to.match(/import/)
+  })
+
   it('make using a missing preprocessor should throw an error', function* () {
     try {
       yield cli.make({

--- a/test/tags/analyzer/valid.tag
+++ b/test/tags/analyzer/valid.tag
@@ -1,5 +1,3 @@
-var riot = require('riot')
-
 <valid-tag>
   <h1>{ title }</h1>
   <p>{ message }</p>

--- a/test/tags/analyzer/valid.tag
+++ b/test/tags/analyzer/valid.tag
@@ -1,3 +1,5 @@
+var riot = require('riot')
+
 <valid-tag>
   <h1>{ title }</h1>
   <p>{ message }</p>


### PR DESCRIPTION
Addresses riot/riot Issue #2604.
Adds adds additional modular option that uses es6 import syntax.
The new option is name es6Modular with M as the alias.

