### PR TITLE
adds new esm option to lib/index.js

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -79,6 +79,7 @@ const cli = co.wrap(function*(ar) {
       sourcemap: args.sourcemap ? 'inline' : false,
       expr: args.expr,
       modular: args.modular,
+      esm: args.esm,
       silent: !!args.stdout || args.silent,
       whitespace: args.whitespace
     },


### PR DESCRIPTION
Missed addition of esm arg to lib/index.js in last PR #32.  This PR adds esm arg to lib/index.js.